### PR TITLE
Add the `--no-asset-precompilation` flag and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This script can be used to deploy this app to remote servers.
     -h, --help                       Prints this help
     -b, --branch=BRANCH              Deploy the code from the passed Git branch
         --no-migrations              Do not carry out migrations
+        --no-asset-precompilation    Skip asset precompilation during deployment
 ```
 
 ### Example of commands
@@ -196,6 +197,15 @@ deploy
 ```
 
 These tasks will only run when the `:web` role is added to the deployment stage.
+
+## Database migrations and asset precompilation
+
+In order for the `--no-migrations` and `--no-asset-precompilation` flags to work correctly, you need to use this configuration in your `Capfile`:
+
+```rb
+require 'capistrano/rails/assets' if ::ENV['NO_ASSET_PRECOMPILATION'].nil?
+require 'capistrano/rails/migrations' if ::ENV['NO_MIGRATIONS'].nil?
+```
 
 ## Development
 

--- a/lib/capistrano/data_plane_api/deploy/args.rb
+++ b/lib/capistrano/data_plane_api/deploy/args.rb
@@ -11,7 +11,7 @@ module Capistrano
       # passed to the deployment script and saves them in
       # an object.
       class Args
-        PRINTABLE_ENV_VARS = %w[BRANCH NO_MIGRATIONS].freeze
+        PRINTABLE_ENV_VARS = %w[BRANCH NO_MIGRATIONS NO_ASSET_PRECOMPILATION].freeze
 
         #: (Array[untyped]?) -> instance
         def self.parse(options = nil) # rubocop:disable Metrics/MethodLength, Style/ClassMethodsDefinitions
@@ -155,6 +155,13 @@ module Capistrano
             ) do |val|
               args.no_migrations = val
               ::ENV['NO_MIGRATIONS'] = 'true'
+            end
+
+            parser.on(
+              '--no-asset-precompilation',
+              'Skip asset precompilation during deployment',
+            ) do
+              ::ENV['NO_ASSET_PRECOMPILATION'] = 'true'
             end
           end
 


### PR DESCRIPTION
This PR introduces the `--no-asset-precompilation` flag to improve flexibility during deployment.
Additionally, the README has been updated to document the new flag and provide config instructions.
